### PR TITLE
remove descriptor handling support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,4 @@ from .src import (
     AggregateSpends,
     BitcoindRPC,
     BitcoindRPCError,
-    descriptor_analysis,
-    IncompatibleDescriptor,
 )

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,17 +17,8 @@ node = "bitcoind" # only `bitcoind` is supported
 ```
 [wallet]
 wallet_name = "" # name of the descriptor wallet
-
-desc = "wsh(and_v(v:pk(tpubD6NzVbkrYhZ4WVLXUV8feb3wGeDj7ifwFCprLS5mMgod52gHEhdf5eRbHLfKpK7Quev91HYkP1TzooEM9jzY331ViXWzDbeWc4hFy9QdS3R/0/*),or_d(pk(tprv8ZgxMBicQKsPcu7atsTZmCB59KA6mhFr4TyKBghM7Tqu3cNHxVD2S2KFoth2b7c9tZsD3PetrANdQ8oc5KUw3KcZr273Vgxrd1dTzyGepSG/0/*),older(12960))))#uayvvntz" # descriptor of the wallet above
-
 change_wallet_name = "" # name of the change descriptor wallet
 
-change_desc = "wsh(and_v(v:pk(tpubD6NzVbkrYhZ4WVLXUV8feb3wGeDj7ifwFCprLS5mMgod52gHEhdf5eRbHLfKpK7Quev91HYkP1TzooEM9jzY331ViXWzDbeWc4hFy9QdS3R/1/*),or_d(pk(tprv8ZgxMBicQKsPcu7atsTZmCB59KA6mhFr4TyKBghM7Tqu3cNHxVD2S2KFoth2b7c9tZsD3PetrANdQ8oc5KUw3KcZr273Vgxrd1dTzyGepSG/1/*),older(12960))))#acuwcxfl" # descriptor for the change wallet. This is not required, it's just used  in the tests
-
-# This options are set by resigner and would be ignored if set
-min_required_sigs = 
-lock_type =  
-lock_value = 
 ```
 
 ### Bitcoind RPC options

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,4 @@
 from .main import local_main
 from .config import Configuration
 from .bitcoind_rpc_client import BitcoindRPC, BitcoindRPCError
-from .analysis import descriptor_analysis
 from .models import AggregateSpends
-from .errors import IncompatibleDescriptor

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -5,20 +5,10 @@ import logging
 from .errors import (
     PSBTPartialSignatureCountError,
     UnsafePSBTError,
-    InsaneTimelock,
-    DuplicateKey,
-    IncompatibleDescriptor,
-    InvalidDescriptor,
     UtxoError,
 )
 
 from .bitcoind_rpc_client import BitcoindRPC, BitcoindRPCError
-from .bip380.descriptors import (
-    Descriptor,
-    WshDescriptor,
-    DescriptorParsingError
-)
-
 from .crypto.hd import HDPrivateKey, HDPublicKey
 from .config import Configuration
 from .models import (
@@ -31,200 +21,6 @@ from .models import (
 SATS = 100000000
 
 logger = logging.getLogger("resigner")
-
-def descriptor_analysis(config: Configuration) -> None:
-    MIN_LOCKTIME_SECS: int = 7776000  # Minimum time that should elapse before a user can spend without Resigner
-    MIN_LOCKTIME_HEIGHT: int = 12960  # Minimum amount of blocks to be created before a user can spend without Resigner
-    MAX_LOCKTIME_SECS: int  # Maximum time that should elapse in unixtime(seconds) before a user can spend without Resigner
-    MAX_LOCKTIME_HEIGHT:int  # Maximum amount of blocks created before a user can spend without Resigner
-
-    desc = config.get("wallet")["desc"]
-    wsh_desc: WshDescriptor = None
-
-    # Example of miniscript policy patterns for use with Resigner
-    # and_v(or_c(pk(resigner),v:older(1004)),multi(1,participant_1,participant_2))
-    # and_v(v:pk(user),or_d(pk(resigner),older(12960)))
-
-    # We only support p2wsh at this time.
-    if desc.startswith("wsh("):
-        try:
-            wsh_desc = Descriptor.from_str(desc)
-        except DescriptorParsingError as e:
-            raise InvalidDescriptor(e)
-    elif desc.startswith("tr("):
-        #TODO: add taproot support
-        raise NotImplementedError("taproot support not implemented")
-    elif desc.startswith("wpkh("):
-        raise IncompatibleDescriptor("Support for wpkh descriptors does not make sense for Resigner")
-    else:
-        raise InvalidDescriptor(f"Unsupported descriptors format: {desc}")
-
-    # Require atleast 2 keys: Resigner and some other cosigner
-    if len(wsh_desc.keys) < 2:
-        raise IncompatibleDescriptor("Requires at least 2 keys in descriptor")
-
-    logger.info("wallet descriptor: %s", wsh_desc)
-    # Check for duplicate keys
-    dupkeys = []
-    keys = []
-    for key in wsh_desc.keys:
-        key_str = str(key)
-        if key_str not in keys:
-            keys.append(key_str)
-        else:
-            dupkeys.append(key_str)
-
-    if len(dupkeys) > 0:
-        raise DuplicateKey("Duplicate Keys exist in Descriptor: {wsh_desc}\nKeys: {dupkeys}")
-
-    # Atleast one of the keys in the descriptor should be a wildcard, to allow for new addresses
-    # to created deterministically. The Xpub corresponding to Resigner's key should be a wildcard key
-    #in the form [84h/0h/0h]xpub/0/* or xpub/84h/0h/0h/0/*, so that every participant can generate a new address irrespective
-    # of resigner or other participants.
-    # Note: Resigners key in the descriptor we import would be an Xpriv, but we pass a descriptor with
-    # an xpub to other participants.
-    service_key = None  # our key
-    for key in wsh_desc.keys:
-        if key.derived_from_xpriv:
-            service_key = key
-            path = service_key.path  # derivation_path()
-            if path is None:
-                raise IncompatibleDescriptor("Expected Signing key to have a derivation path")
-            if not path.kind.is_wildcard():
-                raise IncompatibleDescriptor("Signing key derivation path should be a wildcard")
-            break;
-
-    if not service_key:
-        raise IncompatibleDescriptor("Signing key not in descriptor!")
-
-    # Top-level satisfactions should require a signature. Is this necessary?
-    if not wsh_desc.witness_script.needs_sig:
-        raise InvalidDescriptor("Top level sats should require signatures")
-
-    # Check that policy is consistent with Resigner policy. Resigner policy requires that
-    # 1. No satisfactions that doesn't require the services' signature exist's in the miniscript 
-    # 2. Any other satisfactions to the miniscript be on the condition that a relative block count
-    #    unix time has elapsed.
-
-    # All second-level nodes? having sats not requiring a signature should be timelocks.
-    # We ignore preimages. Those shouldn't be in the second level anyway? 
-
-    # The resigner miniscript can have "andor", "and", "or" top level fragment, hence algorithm
-    # for analysing the miniscript is as follows:
-    # 1. "andor": if first condition fails, the execute 3rd condition else execute second condition.
-    # Hence if service key is in first node or second node, then the third node has the relative lock condition 
-    # 2. "and": top level nodes are "or" and "andor". service key and relative lock condition
-    # are in the same node fragment
-    # 3. "or": top level nodes are "and" and "andor". The rules for the fragment above apply
-
-    def has_service_key(sub):
-        for key in sub.keys:
-            if key.derived_from_xpriv:
-                return True
-        return False
-
-    def  get_relative_lock_node(sub):
-        if sub.rel_heightlocks or sub.rel_timelocks:
-            for sub_l in sub.subs:
-                if sub_l.__repr__().startswith("older("):
-                    return sub_l
-        else:
-            return None
-
-    def get_relative_lock_node_andor(sub):
-        if sub.__repr__().startswith("andor"):
-            if has_service_key(sub.subs[0]) or has_service_key(sub.subs[1]):
-                node = get_relative_lock_node(sub.subs[2])
-                if not node:
-                    return parse_node(sub.subs[2])
-                return node
-            elif sub.subs[2].rel_timelocks or sub.subs[2].rel_heightlocks:
-                return parse_node(sub.subs[2])
-            else:
-                raise IncompatibleDescriptor("Inconsistent miniscript")
-
-    def get_relative_lock_node_and(sub):
-        if sub.__repr__().startswith("and"):
-            for sub_l in sub.subs:
-                if has_service_key(sub_l) and (sub_l.rel_timelocks or sub_l.rel_heightlocks):
-                    if sub_l.__repr__().startswith("andor"):
-                        return get_relative_lock_node_andor(sub_l)
-                    elif  sub_l.__repr__().startswith("or"):
-                        return parse_node(sub_l)
-        return None
-
-                        
-    def parse_node(node):
-        if not node:
-            return node
-
-        if node.__repr__().startswith("and_"):
-            return get_relative_lock_node_and(node)
-        elif node.__repr__().startswith("andor"):
-            return get_relative_lock_node_andor(node)
-        elif node.__repr__().startswith("or_"):
-            # We should avoid such circuitous miniscript
-            sub1 = parse_node(node.subs[0])
-            sub2 = parse_node(node.subs[1])
-
-            return sub1 if sub1 else sub2
-        else:
-            if node.__repr__().startswith("older"):
-                return node
-            elif node.rel_heightlocks or node.rel_timelocks:
-                return parse_node(node)
-
-    rel_lock_sub = parse_node(wsh_desc.witness_script)
-    if not rel_lock_sub:
-        raise IncompatibleDescriptor(f"Could not find the node containing time lock")
-
-    if rel_lock_sub.rel_heightlocks or rel_lock_sub.rel_timelocks:
-        if rel_lock_sub.rel_heightlocks:
-            if rel_lock_sub.value < MIN_LOCKTIME_HEIGHT:
-                raise IncompatibleDescriptor(f"minimum locktime in blocks: {MIN_LOCKTIME_HEIGHT}. "\
-                        f"But was set to {rel_lock_sub.value}")
-        if rel_lock_sub.rel_timelocks:
-            if rel_lock_sub.value < MIN_LOCKTIME_SECS:
-                raise IncompatibleDescriptor(f"minimum locktime in seconds: {MIN_LOCKTIME_SECS}. "\
-                        "But was set to {rel_lock_sub.value}")
-        # Cannot fail now
-        if rel_lock_sub.__repr__().startswith("older("):
-            config.set(
-                {
-                    "lock_type": 1 if rel_lock_sub.rel_heightlocks else 2,
-                    "lock_value": rel_lock_sub.value
-                },
-                "wallet"
-            )
-
-    key = None
-    min_required_sigs = 0
-    for sub in wsh_desc.witness_script.subs:
-        if not sub.needs_sig:
-            if (not sub.rel_timelocks and not sub.rel_heightlocks):
-                raise IncompatibleDescriptor(
-                    "All second level miniscript node sats should include signatures or be timelocks."
-                    )
-
-        if sub.rel_heightlocks or sub.rel_timelocks:
-            if len(sub.keys) == 1:
-                key = sub.keys[0]
-                if key.derived_from_xpriv:
-                    if not str(service_key) == str(key):
-                        raise IncompatibleDescriptor("There are multiple xprivs in descriptor.")
-                    if len(sub.subs) == 2:  # Cannot fail now
-                        for sub in sub.subs:
-                            if sub.needs_sig:
-                                # Minimum no of signature required to satisfy miniscript
-                                min_required_sigs += 1
-                if sub.needs_sig:
-                    # Minimum no of signature required to satisfy miniscript
-                    min_required_sigs += 1
-
-    logger.info("Minimum signatures required to satisfy descriptor: %d", min_required_sigs)
-    if min_required_sigs > 0:
-        config.set({"min_required_sigs": min_required_sigs}, "wallet")
-
 
 class UtxosType(TypedDict):
     txid: str
@@ -285,10 +81,6 @@ def analyse_psbt_from_base64_str(psbt: str, config: Configuration) -> ResignerPs
     third_party_utxos: List[Utxos] = []
     recipient: List[Recipient] = []
 
-    wallet = config.get("wallet")
-    lock_value = None
-    if "lock_value" in wallet:
-        lock_value = wallet["lock_value"] if wallet["lock_type"] == 1 else (wallet["lock_value"]/(60*10))
     # build utxo list
     for utxo in psbt_vin:
         txout =  btd_client.gettxout(utxo["txid"], utxo["vout"])
@@ -296,13 +88,11 @@ def analyse_psbt_from_base64_str(psbt: str, config: Configuration) -> ResignerPs
             logger.error(f"UTXO txid:{utxo['txid']}, vout: {utxo['vout']}, appears to have been spent")
             raise UtxoError(utxo["txid"], utxo["vout"])
         # Get relative lock
-        lock_value = lock_value
         tx_utxo = {
                     "txid": utxo["txid"],
                     "vout": utxo["vout"],
                     "value": txout["value"],
-                    "safe_to_spend": (txout["confirmations"] >= 6) if not txout["coinbase"] else (txout["confirmations"] >= 100),
-                    "can_be_spent_without_resigner": False if lock_value is None else (lock_value >= txout["confirmations"])
+                    "safe_to_spend": (txout["confirmations"] >= 6) if not txout["coinbase"] else (txout["confirmations"] >= 100)
         }
 
         # Check that the utxo is in the db.
@@ -356,11 +146,6 @@ def analyse_psbt_from_base64_str(psbt: str, config: Configuration) -> ResignerPs
             "ismine": ismine
         }
         recipient.append(recv)
-        
-    #self.can_spend_all_utxo
-
-    #num_of_sigs = len(decoded_psbt["partial_signatures"])
-    #min_required_sigs = wallet["min_required_sigs"]
 
     safe_to_sign = all(utxo["safe_to_spend"] for utxo in utxos)
     if not safe_to_sign:
@@ -370,15 +155,6 @@ def analyse_psbt_from_base64_str(psbt: str, config: Configuration) -> ResignerPs
     fee = None
     if "fee" in decoded_psbt:
         fee = decoded_psbt["fee"]
-    # TODO: check that psbt contain enough signatures, such that we can finalise the psbt with our signature
-    # check that the witness script passes with the available signatures
-    # we preferably would not return a psbt with the signing service's signature,
-    # if the serialised transaction cannot be validated there after.
-
-    # Resigner miniscript has a condition allowing coins to be spent after a certain period of time
-    # We shouldn't sign the psbt if the coins can already be spent with resigner and if it contains enough
-    # partial signatures to facilitate spends. This would require signing inputs independently which might not
-    # be possible with bitcoind 
 
     return ResignerPsbt(
             psbt,

--- a/src/errors.py
+++ b/src/errors.py
@@ -15,32 +15,6 @@ class BadArgumentError(Exception):
         self.message = msg
 
 
-class DescriptorError(Exception):
-    pass
-
-
-class InsaneTimelock(DescriptorError):
-    def __init__(self, message = "Timelock specified in miniscript is unreasonable"):
-        self.message = message
-
-
-class DuplicateKey(DescriptorError):
-    def __init__(self, message="Duplicate keys exist in Descriptor"):
-        self.message = message
-
-
-class IncompatibleDescriptor(DescriptorError):
-    def __init__(self, message="Descriptor policy specified is incompatible with Resigner"):
-        self.message = message
-
-
-class InvalidDescriptor(DescriptorError):
-    """Basically every other error generated from bip380"""
-
-    def __init__(self, message):
-        self.message = message
-
-
 class PSBTError(Exception):
     pass
 
@@ -55,15 +29,18 @@ class PSBTPartialSignatureCountError(PSBTError):
     def __init__(self, message = "PSBT contains fewer partial signatures than required"):
         self.message = message
 
+
 class UtxoError(PSBTError):
     def __init__(self, txid: str, vout: int, message: str = None):
         self.message = message or "UTXO specified in the input appears to have been spent"
         self.txid = txid
         self.vout = vout
 
+
 class ServerError(Exception):
     def __init__(self, message):
         self.message = message
+
 
 class DBError(Exception):
     def __init__(self, message):

--- a/src/main.py
+++ b/src/main.py
@@ -30,7 +30,7 @@ from .models import (
     AggregateSpends
 )
 
-from .analysis import descriptor_analysis, ResignerPsbt, analyse_psbt_from_base64_str
+from .analysis import ResignerPsbt, analyse_psbt_from_base64_str
 
 
 def setup_logging(name="resigner"):  
@@ -224,9 +224,6 @@ def local_main(debug: Optional[bool] = False, port: Optional[int] = 7767):
     config.set({"client": btd_client}, "bitcoind")
     config.set({"change_client": btd_change_client}, "bitcoind")
     config.set({"logger": logger})
-
-    # Analyse Descriptor
-    descriptor_analysis(config)
 
     # Init DB
     init_db()

--- a/tests/bitcoin.conf
+++ b/tests/bitcoin.conf
@@ -1,0 +1,17 @@
+regtest=1
+
+# [rpc]
+server=1
+rpcuser=user
+rpcpassword=passwd
+rpcservertimeout=600
+
+# [blockchain]
+txindex=1
+
+# [others]
+daemon=1
+debug=1
+fallbackfee=0.00001
+minrelaytxfee=0
+blockmintxfee=0

--- a/tests/config_test.toml
+++ b/tests/config_test.toml
@@ -6,12 +6,7 @@ node = "bitcoind" # we only support bitcoind
 
 [wallet]
 wallet_name = "resigner_wallet"
-
-desc = "wsh(and_v(v:pk(tpubD6NzVbkrYhZ4WVLXUV8feb3wGeDj7ifwFCprLS5mMgod52gHEhdf5eRbHLfKpK7Quev91HYkP1TzooEM9jzY331ViXWzDbeWc4hFy9QdS3R/0/*),or_d(pk(tprv8ZgxMBicQKsPcu7atsTZmCB59KA6mhFr4TyKBghM7Tqu3cNHxVD2S2KFoth2b7c9tZsD3PetrANdQ8oc5KUw3KcZr273Vgxrd1dTzyGepSG/0/*),older(12960))))#uayvvntz"
-
 change_wallet_name = "resigner_change_wallet"
-
-change_desc = "wsh(and_v(v:pk(tpubD6NzVbkrYhZ4WVLXUV8feb3wGeDj7ifwFCprLS5mMgod52gHEhdf5eRbHLfKpK7Quev91HYkP1TzooEM9jzY331ViXWzDbeWc4hFy9QdS3R/1/*),or_d(pk(tprv8ZgxMBicQKsPcu7atsTZmCB59KA6mhFr4TyKBghM7Tqu3cNHxVD2S2KFoth2b7c9tZsD3PetrANdQ8oc5KUw3KcZr273Vgxrd1dTzyGepSG/1/*),older(12960))))#acuwcxfl"
 
 [bitcoind]
 network = "regtest" # ["regtest", "mainnet"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,8 +143,7 @@ def resigner_wallet(config, funder):
         btd_client.createwallet(wallet_name, False, True, "", False, True)
 
         btd_client._url=f"{bitcoind['rpc_url']}/wallet/{wallet_name}"
-        wallet = config.get("wallet")
-        desc = wallet["desc"]
+        desc = "wsh(and_v(v:pk(tpubD6NzVbkrYhZ4WVLXUV8feb3wGeDj7ifwFCprLS5mMgod52gHEhdf5eRbHLfKpK7Quev91HYkP1TzooEM9jzY331ViXWzDbeWc4hFy9QdS3R/0/*),or_d(pk(tprv8ZgxMBicQKsPcu7atsTZmCB59KA6mhFr4TyKBghM7Tqu3cNHxVD2S2KFoth2b7c9tZsD3PetrANdQ8oc5KUw3KcZr273Vgxrd1dTzyGepSG/0/*),older(12960))))#uayvvntz"
 
         request = [
             {
@@ -185,8 +184,7 @@ def resigner_change_wallet(config, funder):
         btd_client.createwallet(wallet_name, False, True, "", False, True)
 
         btd_client._url=f"{bitcoind['rpc_url']}/wallet/{wallet_name}"
-        wallet = config.get("wallet")
-        desc = wallet["change_desc"]
+        desc = "wsh(and_v(v:pk(tpubD6NzVbkrYhZ4WVLXUV8feb3wGeDj7ifwFCprLS5mMgod52gHEhdf5eRbHLfKpK7Quev91HYkP1TzooEM9jzY331ViXWzDbeWc4hFy9QdS3R/1/*),or_d(pk(tprv8ZgxMBicQKsPcu7atsTZmCB59KA6mhFr4TyKBghM7Tqu3cNHxVD2S2KFoth2b7c9tZsD3PetrANdQ8oc5KUw3KcZr273Vgxrd1dTzyGepSG/1/*),older(12960))))#acuwcxfl"
 
         request = [
             {

--- a/tests/test_framework/descriptors.py
+++ b/tests/test_framework/descriptors.py
@@ -1,8 +1,3 @@
-import pytest
-
-from ..src.analysis import descriptor_analysis
-from ..src import IncompatibleDescriptor
-
 MIN_LOCKTIME_HEIGHT = 12960
 MIN_LOCKTIME_SECS = 7776000
 
@@ -22,36 +17,3 @@ DESCRIPTORS = [
     f"wsh(and_v(or_c(pk({resigner_xpriv}),or_c(pk({recovery_key}),v:older(12990))),pk({participant_2})))"
 ]
 
-def test_descriptors(config):
-
-    # Single user
-    config.set({"desc": DESCRIPTORS[0]}, "wallet")
-    try:
-        descriptor_analysis(config)
-    except Exception as excinfo:
-        pytest.fail(f"unexpected Exception raised: {excinfo}")
-
-    # TimeLock test
-    config.set({"desc": DESCRIPTORS[1]}, "wallet")
-    with pytest.raises(IncompatibleDescriptor) as excinfo:
-        descriptor_analysis(config)
-    assert str(excinfo.value) == f"minimum locktime in blocks: {MIN_LOCKTIME_HEIGHT}. But was set to 8960"
-
-    # Testing more complex miniscript
-    config.set({"desc": DESCRIPTORS[3]}, "wallet")
-    try:
-        descriptor_analysis(config)
-    except Exception as excinfo:
-        pytest.fail(f"unexpected Exception raised: {excinfo}")
-
-    config.set({"desc": DESCRIPTORS[3]}, "wallet")
-    try:
-        descriptor_analysis(config)
-    except Exception as excinfo:
-        pytest.fail(f"unexpected Exception raised: {excinfo}")
-
-    config.set({"desc": DESCRIPTORS[3]}, "wallet")
-    try:
-        descriptor_analysis(config)
-    except Exception as excinfo:
-        pytest.fail(f"unexpected Exception raised: {excinfo}")


### PR DESCRIPTION
resigner shouldn't really care much about low level details of miniscript, since resigner would be used in conjunction with some miniscript-enabled wallet, so it's the wallet's job to make sure that the policy makes sense.